### PR TITLE
[CM-842] Added downloadImageUrlV2  method to support google image url

### DIFF
--- a/Sources/include/ALMessageClientService.h
+++ b/Sources/include/ALMessageClientService.h
@@ -62,6 +62,10 @@
 
 - (void)downloadImageThumbnailUrl:(ALMessage *)message
                    withCompletion:(void(^)(NSString *fileURL, NSError *error)) completion DEPRECATED_ATTRIBUTE;
+- (void)downloadImageThumbnailUrlV2:(NSString *)url
+                            isS3URL:(BOOL)isS3URL
+                          blobKey:(NSString *)blobKey
+                       completion:(void(^)(NSString *fileURL, NSError *error)) completion;
 
 - (void)getLatestMessageForUser:(NSString *)deviceKeyString
                withMetaDataSync:(BOOL)isMetaDataUpdate

--- a/Sources/include/ALMessageClientService.h
+++ b/Sources/include/ALMessageClientService.h
@@ -54,6 +54,8 @@
 
 - (void)downloadImageUrl:(NSString *)blobKey withCompletion:(void(^)(NSString *fileURL, NSError *error)) completion;
 
+- (void)downloadImageUrlV2:(NSString *)blobKey isS3URL:(BOOL)isS3URL withCompletion:(void(^)(NSString *fileURL, NSError *error)) completion;
+
 - (void)downloadImageThumbnailUrl:(NSString *)url
                           blobKey:(NSString *)blobKey
                        completion:(void(^)(NSString *fileURL, NSError *error)) completion;

--- a/Sources/message/ALMessageClientService.m
+++ b/Sources/message/ALMessageClientService.m
@@ -75,6 +75,41 @@
 
 }
 
+- (void)downloadImageUrlV2:(NSString *)blobKey
+                   isS3URL:(BOOL)isS3URL
+          withCompletion:(void(^)(NSString *fileURL, NSError *error)) completion {
+    [self getURLRequestForImageV2:blobKey isS3URL:isS3URL  withCompletion:^(NSMutableURLRequest *urlRequest, NSString *fileUrl) {
+
+        if (!urlRequest
+            && !fileUrl) {
+
+            NSError *urlError = [NSError errorWithDomain:@"Applozic"
+                                                    code:1
+                                                userInfo:@{NSLocalizedDescriptionKey : @"Failed to get the download url"}];
+
+            completion(nil, urlError);
+            return;
+        }
+
+        if (urlRequest) {
+            [self.responseHandler authenticateAndProcessRequest:urlRequest andTag:@"FILE DOWNLOAD URL" WithCompletionHandler:^(id theJson, NSError *theError) {
+
+                if (theError) {
+                    completion(nil, theError);
+                    return;
+                }
+                NSString *imageDownloadURL = (NSString *)theJson;
+                ALSLog(ALLoggerSeverityInfo, @"Response URL for image or attachment : %@",imageDownloadURL);
+                completion(imageDownloadURL, nil);
+            }];
+        } else {
+            completion(fileUrl, nil);
+        }
+    }];
+
+}
+
+
 - (void)getURLRequestForImage:(NSString *)blobKey
                         withCompletion:(void(^)(NSMutableURLRequest *urlRequest, NSString *fileUrl)) completion {
 
@@ -95,6 +130,24 @@
         return;
     } else {
         NSString *fileURLString = [NSString stringWithFormat:@"%@/rest/ws/aws/file/%@",KBASE_FILE_URL,blobKey];
+        completion(nil, fileURLString);
+        return;
+    }
+}
+
+
+- (void)getURLRequestForImageV2:(NSString *)blobKey
+                        isS3URL:(BOOL)isS3URL
+                        withCompletion:(void(^)(NSMutableURLRequest *urlRequest, NSString *fileUrl)) completion {
+
+    NSMutableURLRequest *urlRequest = nil;
+    if (isS3URL) {
+        NSString *fileURLString = [NSString stringWithFormat:@"%@/rest/ws/file/url",KBASE_FILE_URL];
+        NSString *blobParamString = [@"" stringByAppendingFormat:@"key=%@",blobKey];
+        urlRequest = [ALRequestHandler createGETRequestWithUrlString:fileURLString paramString:blobParamString];
+        completion(urlRequest, nil);
+    } else {
+        NSString *fileURLString = [NSString stringWithFormat:@"%@/rest/ws/aws/file/%@",@"https://applozic.appspot.com" ,blobKey];
         completion(nil, fileURLString);
         return;
     }


### PR DESCRIPTION
## Summary
- Added `downloadImageUrlV2` flow to download images based on url type instead of service type
- This will support both s3 as well as google service uploaded images