### PR TITLE
[CM-962] In App Notification Tile issue for lengthy messages | iOS SDK

### DIFF
--- a/Sources/push/TSMessageView.m
+++ b/Sources/push/TSMessageView.m
@@ -332,8 +332,8 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
             }
             [self.contentLabel setShadowColor:self.titleLabel.shadowColor];
             [self.contentLabel setShadowOffset:self.titleLabel.shadowOffset];
-            self.contentLabel.lineBreakMode = self.titleLabel.lineBreakMode;
-            self.contentLabel.numberOfLines = 0;
+            // Restricting Notificationt subtitle (Content) to 2 lines. 
+            self.contentLabel.numberOfLines = 2;
 
             [self addSubview:self.contentLabel];
         }


### PR DESCRIPTION
## Summary
- When user sends a long message, in app notification tile shows whole message.

## RootCause
- We are not setting any restriction to the Content line

## Solution
- Fixed it by setting max lines for the content to 2. For lengthy messages in app notification only shows 2 lines & tail will be truncated

**Before Fix:**

<img src = "https://user-images.githubusercontent.com/61688116/173992588-dd49428a-2504-4c10-b1b1-191892b096b4.jpeg" width = 300 height = 500 />

**After Fix:**

![Screenshot 2022-06-16 at 10 09 16 AM](https://user-images.githubusercontent.com/61688116/173992595-e980938f-f510-4f7a-b519-445ba7a04807.png)

