### PR TITLE
[CM-961] Updation of Create Channel Api Endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # CHANGELOG
 
 The changelog for [KommunicateCore-iOS-SDK](https://github.com/Kommunicate-io/KommunicateCore-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateCore-iOS-SDK/releases) on Github.
-
+## [Unreleased] 
+- [CM-961] Updated Create Channel Api endpoint
 ## [1.0.2] 2022-05-05
 - [CM-891] Added feature to stop the publishing offline status when (agent app moves to background(only for agent app)
 ## [1.0.1] 2022-03-22

--- a/Sources/channel/ALChannelClientService.m
+++ b/Sources/channel/ALChannelClientService.m
@@ -19,7 +19,7 @@
 
 static NSString *const CHANNEL_INFO_URL = @"/rest/ws/group/info";
 static NSString *const CHANNEL_SYNC_URL = @"/rest/ws/group/v3/list";
-static NSString *const CREATE_CHANNEL_URL = @"/rest/ws/group/create";
+static NSString *const CREATE_CHANNEL_URL = @"/rest/ws/group/v2.1/create";
 static NSString *const DELETE_CHANNEL_URL = @"/rest/ws/group/delete";
 static NSString *const LEFT_CHANNEL_URL = @"/rest/ws/group/left";
 static NSString *const ADD_MEMBER_TO_CHANNEL_URL = @"/rest/ws/group/add/member";

--- a/Sources/include/ALMessage.h
+++ b/Sources/include/ALMessage.h
@@ -31,9 +31,6 @@ static NSString *const AL_MESSAGE_REPLY_KEY = @"AL_REPLY";
 static NSString *const AL_OUT_BOX = @"5";
 static NSString *const AL_IN_BOX = @"4";
 static NSString * const AL_RESET_UNREAD_COUNT = @"AL_RESET_UNREAD_COUNT";
-static NSString * const KM_ASSIGN_TO = @"KM_ASSIGN_TO";
-static NSString * const KM_ASSIGN_TEAM = @"KM_ASSIGN_TEAM";
-static NSString * const KM_ASSIGN = @"KM_ASSIGN";
 
 typedef enum {
     AL_NOT_A_REPLY,

--- a/Sources/include/ALMessage.h
+++ b/Sources/include/ALMessage.h
@@ -31,6 +31,9 @@ static NSString *const AL_MESSAGE_REPLY_KEY = @"AL_REPLY";
 static NSString *const AL_OUT_BOX = @"5";
 static NSString *const AL_IN_BOX = @"4";
 static NSString * const AL_RESET_UNREAD_COUNT = @"AL_RESET_UNREAD_COUNT";
+static NSString * const KM_ASSIGN_TO = @"KM_ASSIGN_TO";
+static NSString * const KM_ASSIGN_TEAM = @"KM_ASSIGN_TEAM";
+static NSString * const KM_ASSIGN = @"KM_ASSIGN";
 
 typedef enum {
     AL_NOT_A_REPLY,

--- a/Sources/message/ALMessage.m
+++ b/Sources/message/ALMessage.m
@@ -205,7 +205,7 @@ static NSString * const AL_TRUE = @"true";
 - (BOOL)isHiddenMessage {
     return ((self.contentType == ALMESSAGE_CONTENT_HIDDEN) || [self isVOIPNotificationMessage]
             || [self isPushNotificationMessage] || [self isMessageCategoryHidden]
-            || self.getReplyType== AL_REPLY_BUT_HIDDEN || self.isMsgHidden );
+            || self.getReplyType== AL_REPLY_BUT_HIDDEN || self.isMsgHidden || (self.metadata[KM_ASSIGN_TO] != nil) || (self.metadata[KM_ASSIGN_TEAM] != nil) || (self.metadata[KM_ASSIGN] != nil));
 }
 
 - (BOOL)isVOIPNotificationMessage {

--- a/Sources/message/ALMessage.m
+++ b/Sources/message/ALMessage.m
@@ -203,9 +203,13 @@ static NSString * const AL_TRUE = @"true";
 
 
 - (BOOL)isHiddenMessage {
-    return ((self.contentType == ALMESSAGE_CONTENT_HIDDEN) || [self isVOIPNotificationMessage]
+    return (self.contentType == ALMESSAGE_CONTENT_HIDDEN) || [self isVOIPNotificationMessage]
             || [self isPushNotificationMessage] || [self isMessageCategoryHidden]
-            || self.getReplyType== AL_REPLY_BUT_HIDDEN || self.isMsgHidden || (self.metadata[KM_ASSIGN_TO] != nil) || (self.metadata[KM_ASSIGN_TEAM] != nil) || (self.metadata[KM_ASSIGN] != nil));
+            || self.getReplyType== AL_REPLY_BUT_HIDDEN || self.isMsgHidden || [self isHiddenMetaData];
+}
+// To Check Metadata for hidden flags
+- (BOOL)isHiddenMetaData {
+    return  ((self.metadata[KM_ASSIGN_TO] != nil) || (self.metadata[KM_ASSIGN_TEAM] != nil) || (self.metadata[KM_ASSIGN] != nil));
 }
 
 - (BOOL)isVOIPNotificationMessage {

--- a/Sources/message/ALMessage.m
+++ b/Sources/message/ALMessage.m
@@ -201,15 +201,10 @@ static NSString * const AL_TRUE = @"true";
             || self.isUploadFailed==YES );
 }
 
-
 - (BOOL)isHiddenMessage {
-    return (self.contentType == ALMESSAGE_CONTENT_HIDDEN) || [self isVOIPNotificationMessage]
+    return ((self.contentType == ALMESSAGE_CONTENT_HIDDEN) || [self isVOIPNotificationMessage]
             || [self isPushNotificationMessage] || [self isMessageCategoryHidden]
-            || self.getReplyType== AL_REPLY_BUT_HIDDEN || self.isMsgHidden || [self isHiddenMetaData];
-}
-// To Check Metadata for hidden flags
-- (BOOL)isHiddenMetaData {
-    return  ((self.metadata[KM_ASSIGN_TO] != nil) || (self.metadata[KM_ASSIGN_TEAM] != nil) || (self.metadata[KM_ASSIGN] != nil));
+            || self.getReplyType== AL_REPLY_BUT_HIDDEN || self.isMsgHidden);
 }
 
 - (BOOL)isVOIPNotificationMessage {
@@ -305,6 +300,7 @@ static NSString * const AL_TRUE = @"true";
 
     // Check messages that we need to hide
     NSArray *keys = [ALApplozicSettings metadataKeysToHideMessages];
+    
     if (keys != nil) {
         for (NSString *key in keys) {
             // If this key is present then it's a hidden message


### PR DESCRIPTION
## Summary
- Empty Message is coming if handover option is added in welcome message.
<img width="385" alt="Screenshot 2022-06-15 at 5 01 54 PM" src="https://user-images.githubusercontent.com/61688116/174220067-856646b0-9ac6-4765-b0ee-114f45361f78.png">

## RootCause
- Extra message object is been added with only having metadata of `"KM_ASSIGN_TO" : "id"`.thatswhy empty message in showing on device side
- deviceside create new channel endpoint is older version when comparing to chat widget's

## Solution
- added `KM_ASSIGN,KM_ASSIGN_TO,KM_ASSIGN_TEAM` flags to hidden category & removing messages having those flags same like `"hide": true`
- updated the create channel endpoint same as web chat widget

## Motivation
- Web chat widget following the same way of handling

## After fix

<img src = "https://user-images.githubusercontent.com/61688116/174220635-08a84ee5-0c7e-4a43-94ee-de2adbc2ca50.png" width = 250 height = 400 />
