### PR TITLE
[CM-1013] Logout User from device when password gets changed from dashboard

### DIFF
--- a/Sources/account/ALRegisterUserClientService.m
+++ b/Sources/account/ALRegisterUserClientService.m
@@ -454,6 +454,20 @@
     }];
 }
 
+// Use this only when Logout APi Fails due to authorization
+- (void)logoutUserLocally {
+    [[ALMQTTConversationService sharedInstance] publishOfflineStatus];
+    NSString *userKey = [ALUserDefaultsHandler getUserKeyString];
+    BOOL completed = [[ALMQTTConversationService sharedInstance] unsubscribeToConversation: userKey];
+    ALSLog(ALLoggerSeverityInfo, @"Unsubscribed to conversation after logout: %d", completed);
+
+    [ALUserDefaultsHandler clearAll];
+    [ALApplozicSettings clearAll];
+
+    ALMessageDBService *messageDBService = [[ALMessageDBService alloc] init];
+    [messageDBService deleteAllObjectsInCoreData];
+}
+
 + (BOOL)isAppUpdated {
     
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];

--- a/Sources/account/ALRegisterUserClientService.m
+++ b/Sources/account/ALRegisterUserClientService.m
@@ -435,16 +435,7 @@
 
         ALSLog(ALLoggerSeverityInfo, @"RESPONSE_USER_LOGOUT :: %@", (NSString *)theJson);
         ALAPIResponse *response = [[ALAPIResponse alloc] initWithJSONString:theJson];
-        [[ALMQTTConversationService sharedInstance] publishOfflineStatus];
-        NSString *userKey = [ALUserDefaultsHandler getUserKeyString];
-        BOOL completed = [[ALMQTTConversationService sharedInstance] unsubscribeToConversation: userKey];
-        ALSLog(ALLoggerSeverityInfo, @"Unsubscribed to conversation after logout: %d", completed);
-
-        [ALUserDefaultsHandler clearAll];
-        [ALApplozicSettings clearAll];
-
-        ALMessageDBService *messageDBService = [[ALMessageDBService alloc] init];
-        [messageDBService deleteAllObjectsInCoreData];
+        [self clearLocalDBAndPublishOfflineStatus];
 
         if (error) {
             ALSLog(ALLoggerSeverityError, @"Error in logout: %@", error.description);
@@ -454,8 +445,13 @@
     }];
 }
 
-// Use this only when Logout APi Fails due to authorization
+// This funtion logs out user locally by clearing local DB. Useful when the logout API is not working due to password change and you want to logout.
 - (void)logoutUserLocally {
+    [self clearLocalDBAndPublishOfflineStatus];
+}
+
+// This function changes the status to offline, unsubscribes from MQTT and clears the local data.
+- (void) clearLocalDBAndPublishOfflineStatus {
     [[ALMQTTConversationService sharedInstance] publishOfflineStatus];
     NSString *userKey = [ALUserDefaultsHandler getUserKeyString];
     BOOL completed = [[ALMQTTConversationService sharedInstance] unsubscribeToConversation: userKey];

--- a/Sources/applozickit/ALMQTTConversationService.m
+++ b/Sources/applozickit/ALMQTTConversationService.m
@@ -176,6 +176,11 @@ NSString *const AL_MESSAGE_STATUS_TOPIC = @"message-status";
     [self subscribeToConversationWithTopic:topic withCompletionHandler:^(BOOL subscribed, NSError *error) {
         if (error) {
             ALSLog(ALLoggerSeverityError, @"MQTT : ERROR_IN_SUBSCRIBE :: %@", error.description);
+            if ([error.description  isEqual: @"MQTT CONNACK: bad user name or password"]) {
+                [[NSNotificationCenter defaultCenter] postNotificationName:@"LOGOUT_UNAUTHORIZED_USER"
+                                                                    object:nil
+                                                                  userInfo:nil];
+            }
         }
     }];
 }

--- a/Sources/include/ALRegisterUserClientService.h
+++ b/Sources/include/ALRegisterUserClientService.h
@@ -33,6 +33,8 @@ static NSString *const AL_LOGOUT_URL = @"/rest/ws/device/logout";
 
 - (void)logoutWithCompletionHandler:(void(^)(ALAPIResponse *response, NSError *error))completion;
 
+- (void)logoutUserLocally;
+
 + (BOOL)isAppUpdated;
 
 - (void)syncAccountStatus;

--- a/Sources/networkcommunication/ALResponseHandler.m
+++ b/Sources/networkcommunication/ALResponseHandler.m
@@ -35,6 +35,13 @@ static NSString *const message_SomethingWentWrong = @"SomethingWentWrong";
 
         NSHTTPURLResponse *httpURLResponse = (NSHTTPURLResponse *)response;
 
+        if (httpURLResponse.statusCode == 401) {
+            //Trigger LOGOUT_UNAUTHORIZED_USER notification incase of 401 response.
+            [[NSNotificationCenter defaultCenter] postNotificationName:@"LOGOUT_UNAUTHORIZED_USER"
+                                                                object:nil
+                                                              userInfo:nil];
+        }
+
         if (connectionError.code == kCFURLErrorUserCancelledAuthentication) {
             NSString *failingURL = connectionError.userInfo[@"NSErrorFailingURLStringKey"] != nil ? connectionError.userInfo[@"NSErrorFailingURLStringKey"]:@"Empty";
             ALSLog(ALLoggerSeverityError, @"Authentication error: HTTP 401 : ERROR CODE : %ld, FAILING URL: %@",  (long)connectionError.code,  failingURL);


### PR DESCRIPTION
## Summary
- Logout User from device when password gets changed from dashboard
- triggering logout when api throws 401 & mqtt connect fails due to `MQTT CONNACK: bad user name or password` error
