### PR TITLE
[CM-884] Double Tapping on Notification produces crash 

### DIFF
--- a/Sources/notification/ALNotificationView.m
+++ b/Sources/notification/ALNotificationView.m
@@ -154,6 +154,7 @@
                                        duration:1.75
                                        callback:
      ^(void){
+        [TSMessage dismissActiveNotificationWithCompletion:nil];
         handler(true);
     }
                                     buttonTitle:nil


### PR DESCRIPTION
## Summary
- Fixed double tapping on notification produces crash issue

## Note
- Firebase Crash : https://console.firebase.google.com/u/0/project/kommunicate-c6413/crashlytics/app/ios:io.kommunicate.agent/issues/87cda2f1bc1575c0ca34a7e6d593be10?time=last-ninety-days&sessionEventKey=df2fadbf9732468d88d65921f405b174_1716811741821941519