### PR TITLE
[Cm-787] Changed default Authentication type from 0 to 1

### DIFF
--- a/Sources/prefrence/ALUserDefaultsHandler.m
+++ b/Sources/prefrence/ALUserDefaultsHandler.m
@@ -525,7 +525,7 @@
 + (short)getUserAuthenticationTypeId {
     NSUserDefaults *userDefaults = [ALUserDefaultsHandler getUserDefaults];
     short type = [userDefaults integerForKey:AL_USER_AUTHENTICATION_TYPE_ID];
-    return type ? type : 0;
+    return type ? type : 1;
 }
 
 + (void)setUnreadCountType:(short)mode {


### PR DESCRIPTION
## Summary
- User can login with wrong password & without password as well
- Fixed it by changing the default `authenticationtypeid` to 1 of an user