### PR TITLE
[CM-1124] Fixed un opened conversation being listed on agent app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The changelog for [KommunicateCore-iOS-SDK](https://github.com/Kommunicate-io/KommunicateCore-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateCore-iOS-SDK/releases) on Github.
 
 ##[Unreleased] 
-- 
+- [CM-1124] Fixed un opened conversation added to conversation list screen
 ## [1.0.5] 2022-09-09
 - [CM-787] Fixed the issue of user can login with wrong password
 ## [1.0.4] 2022-06-22

--- a/Sources/channel/ALChannelService.m
+++ b/Sources/channel/ALChannelService.m
@@ -1249,7 +1249,7 @@ dispatch_queue_t channelUserbackgroundQueue;
 - (void)createChannelsAndUpdateInfo:(NSMutableArray *)channelArray withDelegate:(id<ApplozicUpdatesDelegate>)delegate {
 
     for (ALChannel *channelObject in channelArray) {
-        // Ignore inserting un opened conversation(Which doesn't have user messages, only contains wecome messages)
+        // Ignore inserting un opened conversation(Which doesn't have user messages, only contains bot messages)
         NSDictionary *metadata = channelObject.metadata;
         if (metadata && metadata[AL_CHANNEL_CONVERSATION_STATUS] && [metadata[AL_CHANNEL_CONVERSATION_STATUS] isEqual:UN_OPENED_CONVERSATION_STATUS] ) {
             continue;

--- a/Sources/channel/ALChannelService.m
+++ b/Sources/channel/ALChannelService.m
@@ -1249,6 +1249,11 @@ dispatch_queue_t channelUserbackgroundQueue;
 - (void)createChannelsAndUpdateInfo:(NSMutableArray *)channelArray withDelegate:(id<ApplozicUpdatesDelegate>)delegate {
 
     for (ALChannel *channelObject in channelArray) {
+        // Ignore inserting un opened conversation(Which doesn't have user messages, only contains wecome messages)
+        NSDictionary *metadata = channelObject.metadata;
+        if (metadata && metadata[AL_CHANNEL_CONVERSATION_STATUS] && [metadata[AL_CHANNEL_CONVERSATION_STATUS] isEqual:UN_OPENED_CONVERSATION_STATUS] ) {
+            continue;
+        }
         // Ignore inserting unread count in sync call
         channelObject.unreadCount = 0;
         [self createChannelEntry:channelObject fromMessageList:NO];

--- a/Sources/include/ALChannel.h
+++ b/Sources/include/ALChannel.h
@@ -16,6 +16,8 @@ static NSString *const AL_CHANNEL_CONVERSATION_STATUS = @"CONVERSATION_STATUS";
 static NSString *const AL_CATEGORY = @"AL_CATEGORY";
 static NSString *const AL_CONTEXT_BASED_CHAT = @"AL_CONTEXT_BASED_CHAT";
 static NSString *const AL_CONVERSATION_ASSIGNEE = @"CONVERSATION_ASSIGNEE";
+//Channel which doesn't have user messages, only contains bot wecome messages
+static NSString *const UN_OPENED_CONVERSATION_STATUS = @"1";
 
 /*********************
  type = 7 SPECIAL CASE

--- a/Sources/include/ALChannel.h
+++ b/Sources/include/ALChannel.h
@@ -17,7 +17,7 @@ static NSString *const AL_CATEGORY = @"AL_CATEGORY";
 static NSString *const AL_CONTEXT_BASED_CHAT = @"AL_CONTEXT_BASED_CHAT";
 static NSString *const AL_CONVERSATION_ASSIGNEE = @"CONVERSATION_ASSIGNEE";
 //Channel which doesn't have user messages, only contains bot messages
-static NSString *const UN_OPENED_CONVERSATION_STATUS = @"1";
+static NSString *const UN_OPENED_CONVERSATION_STATUS = @"-1";
 
 /*********************
  type = 7 SPECIAL CASE

--- a/Sources/include/ALChannel.h
+++ b/Sources/include/ALChannel.h
@@ -16,7 +16,7 @@ static NSString *const AL_CHANNEL_CONVERSATION_STATUS = @"CONVERSATION_STATUS";
 static NSString *const AL_CATEGORY = @"AL_CATEGORY";
 static NSString *const AL_CONTEXT_BASED_CHAT = @"AL_CONTEXT_BASED_CHAT";
 static NSString *const AL_CONVERSATION_ASSIGNEE = @"CONVERSATION_ASSIGNEE";
-//Channel which doesn't have user messages, only contains bot wecome messages
+//Channel which doesn't have user messages, only contains bot messages
 static NSString *const UN_OPENED_CONVERSATION_STATUS = @"1";
 
 /*********************


### PR DESCRIPTION
## Summary
- Fixed showing un opened conversation(Conversation only have messages from bot, conversation status = -1) on conversation list screen for agent app