### PR TITLE
[CM-1469] Added Support upload attachment size

### DIFF
--- a/Sources/prefrence/ALApplozicSettings.m
+++ b/Sources/prefrence/ALApplozicSettings.m
@@ -187,7 +187,8 @@
 
 + (NSInteger)getMaxImageSizeForUploadInMB {
     NSUserDefaults *userDefaults = [ALApplozicSettings getUserDefaults];
-    return [userDefaults integerForKey:AL_IMAGE_UPLOAD_MAX_SIZE];
+    NSInteger maxSize = [userDefaults integerForKey:AL_IMAGE_UPLOAD_MAX_SIZE];
+    return maxSize? maxSize : 25;
 }
 
 + (void)setMaxCompressionFactor:(double)maxCompressionRatio {

--- a/Sources/utilities/ALUIImage+Utility.m
+++ b/Sources/utilities/ALUIImage+Utility.m
@@ -9,7 +9,7 @@
 #import "ALApplozicSettings.h"
 #import "ALUIImage+Utility.h"
 
-#define  DEFAULT_MAX_FILE_UPLOAD_SIZE 32
+#define  DEFAULT_MAX_FILE_UPLOAD_SIZE 25
 
 @implementation UIImage (Utility)
 


### PR DESCRIPTION
## Summary
- Added support for restriction  upload attachments based on size. By default it is 25 MB. it can be customized based by using below code
```
ALApplozicSettings.setMaxImageSizeForUploadInMB(6)

```

you should import communicate core module whenever you use this customisation like this `import KommunicateCore_iOS_SDK`

 