### PR TITLE
[CM-1652] Fixed conversation history mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 The changelog for [KommunicateCore-iOS-SDK](https://github.com/Kommunicate-io/KommunicateCore-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateCore-iOS-SDK/releases) on Github.
 
+##Unreleased
+- Fixed conversation history mismatch
 ## [1.1.3] 2023-09-26
 - Added elastic update for email updation in IOS SDK
 - Added Support For Auto Suggestions Rich Message

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The changelog for [KommunicateCore-iOS-SDK](https://github.com/Kommunicate-io/KommunicateCore-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateCore-iOS-SDK/releases) on Github.
 
 ##Unreleased
-- Fixed conversation history mismatch
+- Fixed all messages are not loading in conversation screen.
 ## [1.1.3] 2023-09-26
 - Added elastic update for email updation in IOS SDK
 - Added Support For Auto Suggestions Rich Message

--- a/Sources/include/ALMessageService.h
+++ b/Sources/include/ALMessageService.h
@@ -47,6 +47,7 @@ static NSString *const AL_MESSAGE_META_DATA_UPDATE = @"messageMetaDataUpdateNoti
                         channelKey:(NSNumber *)channelKey
                     conversationId:(NSNumber *)conversationId
                         startIndex:(NSInteger)startIndex
+                         startTime:(NSNumber *)startTime
                     withCompletion:(void (^)(NSMutableArray *))completion;
 
 /// This method is used for sending a text message one to one or group conversation.


### PR DESCRIPTION
## Summary
- Users were not able to fetch only first few messages which is fixed now

### Last conversation from ios 
![Simulator Screenshot - iPhone 15 Pro Max - 2023-10-06 at 17 31 22](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139108613/ba367747-ed16-4cfb-91c9-8286de4d3e46)
### Last conversation from android
![Screenshot_20231006-173840](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139108613/a79a1f86-f1cd-4b08-8c06-0fe45e5dd45c)