### PR TITLE
[CM-1759] Quick Reply implementation for TaxBuddy

### DIFF
--- a/Sources/message/ALMessage.m
+++ b/Sources/message/ALMessage.m
@@ -210,8 +210,8 @@ static NSString * const AL_TRUE = @"true";
 
 - (BOOL)isHiddenMessage {
     return ((self.contentType == ALMESSAGE_CONTENT_HIDDEN) || [self isVOIPNotificationMessage]
-            || [self isPushNotificationMessage] || ( [self isMessageCategoryHidden] && self.contentType != 0 )
-            || self.getReplyType== AL_REPLY_BUT_HIDDEN || self.isMsgHidden);
+                || [self isPushNotificationMessage] || [self isMessageCategoryHidden]
+                || self.getReplyType== AL_REPLY_BUT_HIDDEN || self.isMsgHidden);
 }
 
 - (BOOL)isVOIPNotificationMessage {
@@ -328,6 +328,11 @@ static NSString * const AL_TRUE = @"true";
 }
 
 - (BOOL)isMessageCategoryHidden {
+    
+    if ([ALApplozicSettings isAgentAppConfigurationEnabled]) {
+        return false;
+    }
+    
     return (self.metadata && [self.metadata valueForKey:@"category"] &&
             [[self.metadata valueForKey:@"category"] isEqualToString:AL_CATEGORY_HIDDEN]);
 }

--- a/Sources/message/ALMessage.m
+++ b/Sources/message/ALMessage.m
@@ -210,7 +210,7 @@ static NSString * const AL_TRUE = @"true";
 
 - (BOOL)isHiddenMessage {
     return ((self.contentType == ALMESSAGE_CONTENT_HIDDEN) || [self isVOIPNotificationMessage]
-            || [self isPushNotificationMessage] || [self isMessageCategoryHidden]
+            || [self isPushNotificationMessage] || ( [self isMessageCategoryHidden] && self.contentType != 0 )
             || self.getReplyType== AL_REPLY_BUT_HIDDEN || self.isMsgHidden);
 }
 
@@ -329,7 +329,7 @@ static NSString * const AL_TRUE = @"true";
 
 - (BOOL)isMessageCategoryHidden {
     return (self.metadata && [self.metadata valueForKey:@"category"] &&
-            [[self.metadata valueForKey:@"category"] isEqualToString:AL_CATEGORY_HIDDEN] && self.contentType != 0);
+            [[self.metadata valueForKey:@"category"] isEqualToString:AL_CATEGORY_HIDDEN]);
 }
 
 - (BOOL)isAReplyMessage {

--- a/Sources/message/ALMessage.m
+++ b/Sources/message/ALMessage.m
@@ -329,7 +329,7 @@ static NSString * const AL_TRUE = @"true";
 
 - (BOOL)isMessageCategoryHidden {
     return (self.metadata && [self.metadata valueForKey:@"category"] &&
-            [[self.metadata valueForKey:@"category"] isEqualToString:AL_CATEGORY_HIDDEN]);
+            [[self.metadata valueForKey:@"category"] isEqualToString:AL_CATEGORY_HIDDEN] && self.contentType != 0);
 }
 
 - (BOOL)isAReplyMessage {

--- a/Sources/message/ALMessage.m
+++ b/Sources/message/ALMessage.m
@@ -210,8 +210,8 @@ static NSString * const AL_TRUE = @"true";
 
 - (BOOL)isHiddenMessage {
     return ((self.contentType == ALMESSAGE_CONTENT_HIDDEN) || [self isVOIPNotificationMessage]
-                || [self isPushNotificationMessage] || [self isMessageCategoryHidden]
-                || self.getReplyType== AL_REPLY_BUT_HIDDEN || self.isMsgHidden);
+            || [self isPushNotificationMessage] || [self isMessageCategoryHidden]
+            || self.getReplyType== AL_REPLY_BUT_HIDDEN || self.isMsgHidden);
 }
 
 - (BOOL)isVOIPNotificationMessage {


### PR DESCRIPTION
### Overview
Taxbuddy wanted to reassign a conversation back to a bot by using quick replies provided in the dashboard.
We have modified the quickreplies for the same. 
The idea is that they will identify the event at universal webhook and trigger reassignment.

### Code changes

Currently the agent app was not receiving hidden messages, hence added a check to ensure that if a message has `"category":"HIDDEN"`, it is shown in the agent app.

### What do you want to achieve?
- Provide a way to send specific events along with the quickreplies.

## Verified
- [x] SPM

## Video

https://github.com/Kommunicate-io/Kommunicate-iOS-AgentApp/assets/139108613/34869634-833c-445a-93ae-3eb82f819844