### PR TITLE
[CM-1806] Fixed blank message showing in agent app before assignment

### DIFF
--- a/Sources/message/ALMessage.m
+++ b/Sources/message/ALMessage.m
@@ -304,6 +304,10 @@ static NSString * const AL_TRUE = @"true";
 
 - (BOOL)isMsgHidden {
     
+    if (self.isAssignmentMessage && self.message == nil) {
+        return true;
+    }
+    
     if (self.message && ([self.metadata objectForKey:@"KM_ASSIGN_TO"] != nil || [self.metadata objectForKey:@"KM_ASSIGN_TEAM"] != nil)) {
         return false;
     }


### PR DESCRIPTION
### Summary

iOS agent app showing a blank text message before assignment

### Verified
- [x] SPM

### Payload of message

```
{
  "key": "5-97601966-1703571550005",
  "userKey": "d6306c09-5c91-41ca-9c82-a2fcb0178006",
  "to": "custom-pysug",
  "contactIds": "custom-pysug",
  "sent": false,
  "delivered": true,
  "read": false,
  "createdAtTime": 1703571550011,
  "type": 4,
  "source": 4,
  "status": 5,
  "pairedMessageKey": "5-97601966-1703571550005",
  "groupId": 97601966,
  "clientGroupId": "97601966",
  "contentType": 0,
  "metadata": {
    "KM_ASSIGN_TO": "",
    "skipBot": "true"
  }
}
```

### Screenshots

#### Before

<img src="https://github.com/Kommunicate-io/KommunicateCore-iOS-SDK/assets/139108613/fcd2939c-ddf9-48f7-bd91-3a8e55ce7610" alt="Before" width="300" height="500">

#### After

<img src="https://github.com/Kommunicate-io/KommunicateCore-iOS-SDK/assets/139108613/606fcae8-b329-4d28-a907-08ccf200e4cc" alt="After" width="300" height="500">