### PR TITLE
[CM-1713] Zendesk (Zopim) integration optimisations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG
 
 The changelog for [KommunicateCore-iOS-SDK](https://github.com/Kommunicate-io/KommunicateCore-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateCore-iOS-SDK/releases) on Github.
+## Unreleased
+- Zendesk (Zopim) integration optimisations
 ## [1.1.6] 2023-12-23
 - Changed UI for typing indicator in iOS SDK
 - Added feature to trigger intents using quick reply

--- a/Sources/include/ALApplozicSettings.h
+++ b/Sources/include/ALApplozicSettings.h
@@ -673,4 +673,7 @@ static NSString *const KM_IS_SINGLE_THREADED =  @"KM_IS_SINGLE_THREADED";
 + (void) setIsSingleThreadedEnabled: (BOOL) flag;
 + (BOOL) getIsSingleThreadedEnabled;
 
++ (void) setIsChatTranscriptSent:(NSString*)groupId;
++ (BOOL) isChatTranscriptSent:(NSString*)groupId;
+
 @end

--- a/Sources/prefrence/ALApplozicSettings.m
+++ b/Sources/prefrence/ALApplozicSettings.m
@@ -2027,4 +2027,15 @@
     return [userDefaults boolForKey:KM_IS_SINGLE_THREADED];
 }
 
++ (void)setIsChatTranscriptSent:(NSString*)groupId {
+    NSUserDefaults *userDefaults = [ALApplozicSettings getUserDefaults];
+    [userDefaults setBool:true forKey:groupId];
+    [userDefaults synchronize];
+}
+
++ (BOOL)isChatTranscriptSent:(NSString*)groupId {
+    NSUserDefaults *userDefaults = [ALApplozicSettings getUserDefaults];
+    return [userDefaults boolForKey:groupId];
+}
+
 @end


### PR DESCRIPTION
## Summary

- Fixed sync call happening even when new message created at time == last sync time
- For the first time while opening zendesk it was not working because there was no handoff to agent as soon as the conversation is released from the bot
- Fixed chat transcript sending multiple times for zendesk handoff