### PR TITLE
[CM-1863] group/v5 optimisation

### DIFF
--- a/Sources/channel/ALChannelService.m
+++ b/Sources/channel/ALChannelService.m
@@ -25,6 +25,7 @@ NSString *const AL_Updated_Group_Members = @"Updated_Group_Members";
 NSString *const AL_MESSAGE_LIST = @"AL_MESSAGE_LIST";
 NSString *const AL_MESSAGE_SYNC = @"AL_MESSAGE_SYNC";
 NSString *const AL_CHANNEL_MEMBER_CALL_COMPLETED = @"AL_CHANNEL_MEMBER_CALL_COMPLETED";
+NSNumber *syncCallTriggerTime = 0L;
 
 dispatch_queue_t channelUserbackgroundQueue;
 
@@ -732,7 +733,12 @@ dispatch_queue_t channelUserbackgroundQueue;
 - (void)syncCallForChannelWithDelegate:(id<ApplozicUpdatesDelegate>)delegate {
 
     NSNumber *updateAtTime = [ALUserDefaultsHandler getLastSyncChannelTime];
-
+    
+    if ((syncCallTriggerTime != nil || syncCallTriggerTime != 0L) && syncCallTriggerTime == updateAtTime) {
+        return;
+    }
+    
+    syncCallTriggerTime = updateAtTime;
     [self.channelClientService syncCallForChannel:updateAtTime withFetchUserDetails:YES andCompletion:^(NSError *error, ALChannelSyncResponse *response) {
         if (!error) {
             [ALUserDefaultsHandler setLastSyncChannelTime:response.generatedAt];


### PR DESCRIPTION
## Summary
- group/v5 api is getting called from agent for  each messages/covnersation created in the account.
- Lets sat 5 conversations are created & user is opening the agent app, v5 api getting triggered 5 times.
- This unnecessary API calls Creeate high cpu utilisation if number of conversations created is more.
