### PR TITLE
[CM-1827] In App Notification Banner Colour Customization

### DIFF
--- a/Sources/include/ALUtilityClass.h
+++ b/Sources/include/ALUtilityClass.h
@@ -34,6 +34,9 @@ extern NSString * const AL_APP_GROUPS_ACCESS_KEY;
 + (void)thirdDisplayNotificationTS:(NSString *)toastMessage
                    andForContactId:(NSString *)contactId
                        withGroupId:(NSNumber *)groupID
+                    titleTestColor:(UIColor *)titleTextColor
+                  contentTextColor:(UIColor *)contentTextColor
+                   backgroundColor:(UIColor *)backgroundColor
                  completionHandler:(void (^)(BOOL))handler;
 
 + (NSString *)getFileNameWithCurrentTimeStamp;

--- a/Sources/include/ALUtilityClass.h
+++ b/Sources/include/ALUtilityClass.h
@@ -37,6 +37,10 @@ extern NSString * const AL_APP_GROUPS_ACCESS_KEY;
                     titleTestColor:(UIColor *)titleTextColor
                   contentTextColor:(UIColor *)contentTextColor
                    backgroundColor:(UIColor *)backgroundColor
+             backgroundShadowColor:(UIColor *)backgroundShadowColor
+                      shadowRadius:(NSNumber *)shadowRadius
+                      cornerRadius:(NSNumber *)cornerRadius
+                     shadowOpacity:(NSNumber *)shadowOpacity
                  completionHandler:(void (^)(BOOL))handler;
 
 + (NSString *)getFileNameWithCurrentTimeStamp;

--- a/Sources/include/TSMessageView.h
+++ b/Sources/include/TSMessageView.h
@@ -38,6 +38,10 @@
 @property (nonatomic,strong) UIFont *contentFont UI_APPEARANCE_SELECTOR;
 @property (nonatomic,strong) UIColor *contentTextColor UI_APPEARANCE_SELECTOR;
 @property (nonatomic,strong) UIColor *bannerBackgroundColor UI_APPEARANCE_SELECTOR;
+@property (nonatomic,strong) NSNumber *bannerCornerRadius UI_APPEARANCE_SELECTOR;
+@property (nonatomic,strong) NSNumber *bannerShadowRadius UI_APPEARANCE_SELECTOR;
+@property (nonatomic,strong) NSNumber *shadowOpacity UI_APPEARANCE_SELECTOR;
+@property (nonatomic,strong) UIColor *bannerShadowColor UI_APPEARANCE_SELECTOR;
 @property (nonatomic,strong) UIImage *messageIcon UI_APPEARANCE_SELECTOR;
 @property (nonatomic,strong) UIImage *errorIcon UI_APPEARANCE_SELECTOR;
 @property (nonatomic,strong) UIImage *successIcon UI_APPEARANCE_SELECTOR;

--- a/Sources/include/TSMessageView.h
+++ b/Sources/include/TSMessageView.h
@@ -37,6 +37,7 @@
 @property (nonatomic,strong) UIColor *titleTextColor UI_APPEARANCE_SELECTOR;
 @property (nonatomic,strong) UIFont *contentFont UI_APPEARANCE_SELECTOR;
 @property (nonatomic,strong) UIColor *contentTextColor UI_APPEARANCE_SELECTOR;
+@property (nonatomic,strong) UIColor *bannerBackgroundColor UI_APPEARANCE_SELECTOR;
 @property (nonatomic,strong) UIImage *messageIcon UI_APPEARANCE_SELECTOR;
 @property (nonatomic,strong) UIImage *errorIcon UI_APPEARANCE_SELECTOR;
 @property (nonatomic,strong) UIImage *successIcon UI_APPEARANCE_SELECTOR;

--- a/Sources/push/TSMessageView.m
+++ b/Sources/push/TSMessageView.m
@@ -314,7 +314,7 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
 
 
         self.textSpaceLeft = 2 * padding;
-        if (image) self.textSpaceLeft += image.size.width + 2 * padding;
+        if (image) self.textSpaceLeft += image.size.width + padding;
 
         // Set up title label
         _titleLabel = [[UILabel alloc] init];
@@ -378,8 +378,8 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
                                                   image.size.width,
                                                   image.size.height);
             
-            self.iconImageView.layer.cornerRadius=image.size.width/2;
-            self.iconImageView.layer.masksToBounds=YES;
+            self.iconImageView.layer.cornerRadius = image.size.width/2;
+            self.iconImageView.layer.masksToBounds = YES;
             [self addSubview:self.iconImageView];
             
         }
@@ -493,114 +493,48 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
 }
 
 
-- (CGFloat)updateHeightOfMessageView
-{
-    CGFloat currentHeight;
-    CGSize screenSize = [UIScreen mainScreen].bounds.size;
-    CGFloat screenWidth = screenSize.width;
+- (CGFloat)updateHeightOfMessageView {
+    CGFloat currentHeight = 0.0;
     CGFloat padding = [self padding];
-    CGFloat topPadding = padding;
+    CGFloat screenWidth = CGRectGetWidth([UIScreen mainScreen].bounds);
+    CGFloat textSpaceWidth = screenWidth - (padding * 2) - self.textSpaceLeft - self.textSpaceRight;
 
-    if (@available(iOS 11.0, *)) {
-        // Adding full padding adds too much gap in iphone X so, it's 0.3x
-        topPadding = 0.3 * topPadding + self.safeAreaInsets.top;
+    if (self.title.length > 0) {
+        CGSize titleSize = [self.titleLabel sizeThatFits:CGSizeMake(textSpaceWidth, CGFLOAT_MAX)];
+        self.titleLabel.frame = CGRectMake(self.textSpaceLeft, padding * 2 + self.safeAreaInsets.top, textSpaceWidth, titleSize.height);
+        currentHeight += titleSize.height + padding;
     }
 
-    self.titleLabel.frame = CGRectMake(self.textSpaceLeft,
-                                       topPadding,
-                                       screenWidth - padding - self.textSpaceLeft - self.textSpaceRight,
-                                       0.0);
-    [self.titleLabel sizeToFit];
-
-    if ([self.subtitle length])
-    {
-        self.contentLabel.frame = CGRectMake(self.textSpaceLeft,
-                                             self.titleLabel.frame.origin.y + self.titleLabel.frame.size.height + 5.0,
-                                             screenWidth - padding - self.textSpaceLeft - self.textSpaceRight,
-                                             0.0);
-        [self.contentLabel sizeToFit];
-
-        currentHeight = self.contentLabel.frame.origin.y + self.contentLabel.frame.size.height;
-    }
-    else
-    {
-        // only the title was set
-        currentHeight = self.titleLabel.frame.origin.y + self.titleLabel.frame.size.height;
+    if (self.subtitle.length > 0) {
+        CGFloat contentLabelHeight = [self.contentLabel sizeThatFits:CGSizeMake(textSpaceWidth, CGFLOAT_MAX)].height;
+        self.contentLabel.frame = CGRectMake(self.textSpaceLeft, CGRectGetMaxY(self.titleLabel.frame) + padding - 10, textSpaceWidth, contentLabelHeight);
+        currentHeight += contentLabelHeight + padding;
     }
 
-    currentHeight += padding;
-
-    if (self.iconImageView)
-    {
-        // Check if that makes the popup larger (height)
-        if (self.iconImageView.frame.origin.y + self.iconImageView.frame.size.height + padding > currentHeight)
-        {
-            currentHeight = self.iconImageView.frame.origin.y + self.iconImageView.frame.size.height + padding;
-        }
-        else
-        {
-            // z-align
-            self.iconImageView.center = CGPointMake([self.iconImageView center].x,
-                                                    round(currentHeight / 2.0));
-        }
+    if (self.iconImageView) {
+        CGFloat iconY = self.safeAreaInsets.top + (currentHeight / 4) + (padding / 2);
+        CGFloat iconX = self.textSpaceLeft / 1.7 - CGRectGetWidth(self.iconImageView.frame) / 2;
+        self.iconImageView.frame = CGRectMake(iconX, iconY, CGRectGetWidth(self.iconImageView.frame), CGRectGetHeight(self.iconImageView.frame));
     }
 
-    // z-align button
-    self.button.center = CGPointMake([self.button center].x,
-                                     round(currentHeight / 2.0));
-
-    if (self.messagePosition == TSMessageNotificationPositionTop)
-    {
-        // Correct the border position
-        CGRect borderFrame = self.borderView.frame;
-        borderFrame.origin.y = currentHeight;
-        self.borderView.frame = borderFrame;
+    if (self.button) {
+        CGFloat buttonX = screenWidth - padding - CGRectGetWidth(self.button.frame);
+        CGFloat buttonY = currentHeight + padding;
+        self.button.frame = CGRectMake(buttonX, buttonY, CGRectGetWidth(self.button.frame), CGRectGetHeight(self.button.frame));
+        currentHeight += CGRectGetHeight(self.button.frame) + padding;
     }
 
-    currentHeight += self.borderView.frame.size.height;
-
-    self.frame = CGRectMake(0.0, self.frame.origin.y, self.frame.size.width, currentHeight);
-
-
-    if (self.button)
-    {
-        self.button.frame = CGRectMake(self.frame.size.width - self.textSpaceRight,
-                                       round((self.frame.size.height / 2.0) - self.button.frame.size.height / 2.0),
-                                       self.button.frame.size.width,
-                                       self.button.frame.size.height);
+    if (self.messagePosition == TSMessageNotificationPositionTop) {
+        self.borderView.frame = CGRectMake(self.borderView.frame.origin.x, currentHeight, CGRectGetWidth(self.borderView.frame), CGRectGetHeight(self.borderView.frame));
     }
 
+    currentHeight += CGRectGetHeight(self.borderView.frame);
+    self.frame = CGRectMake(0.0, self.frame.origin.y, screenWidth, currentHeight);
 
-    CGRect backgroundFrame = CGRectMake(self.backgroundImageView.frame.origin.x,
-                                        self.backgroundImageView.frame.origin.y,
-                                        screenWidth,
-                                        currentHeight);
-
-    // increase frame of background view because of the spring animation
-    if ([TSMessage iOS7StyleEnabled])
-    {
-        if (self.messagePosition == TSMessageNotificationPositionTop)
-        {
-            float topOffset = 0.f;
-
-            UINavigationController *navigationController = self.viewController.navigationController;
-            if (!navigationController && [self.viewController isKindOfClass:[UINavigationController class]]) {
-                navigationController = (UINavigationController *)self.viewController;
-            }
-            BOOL isNavBarIsHidden = !navigationController || [TSMessage isNavigationBarInNavigationControllerHidden:navigationController];
-            BOOL isNavBarIsOpaque = !navigationController.navigationBar.isTranslucent && navigationController.navigationBar.alpha == 1;
-
-            if (isNavBarIsHidden || isNavBarIsOpaque) {
-                topOffset = -30.f;
-            }
-            backgroundFrame = UIEdgeInsetsInsetRect(backgroundFrame, UIEdgeInsetsMake(topOffset, 0.f, 0.f, 0.f));
-        }
-        else if (self.messagePosition == TSMessageNotificationPositionBottom)
-        {
-            backgroundFrame = UIEdgeInsetsInsetRect(backgroundFrame, UIEdgeInsetsMake(0.f, 0.f, -30.f, 0.f));
-        }
-    }
-
+    UIWindow *keyWindow = [UIApplication.sharedApplication.windows firstObject];
+    CGFloat statusBarHeight = keyWindow.windowScene.statusBarManager.statusBarFrame.size.height;
+    
+    CGRect backgroundFrame = CGRectMake(padding, statusBarHeight + padding, screenWidth - padding * 2, currentHeight + padding);
     self.backgroundImageView.frame = backgroundFrame;
     self.backgroundBlurView.frame = backgroundFrame;
 

--- a/Sources/push/TSMessageView.m
+++ b/Sources/push/TSMessageView.m
@@ -284,7 +284,6 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
             _backgroundBlurView = [[TSBlurView alloc] init];
             self.backgroundBlurView.autoresizingMask = (UIViewAutoresizingFlexibleWidth);
             //            self.backgroundBlurView.blurTintColor = [UIColor colorWithHexString:current[@"backgroundColor"]];
-//            self.backgroundBlurView.blurTintColor = [UIColor redColor];
             [self addSubview:self.backgroundBlurView];
         }
 

--- a/Sources/push/TSMessageView.m
+++ b/Sources/push/TSMessageView.m
@@ -302,9 +302,6 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
         else
         {
             // On iOS 7 and above use a blur layer instead (not yet finished)
-//            _backgroundBlurView = [[TSBlurView alloc] init];
-//            self.backgroundBlurView.autoresizingMask = (UIViewAutoresizingFlexibleWidth);
-            //            self.backgroundBlurView.blurTintColor = [UIColor colorWithHexString:current[@"backgroundColor"]];
             _backgroundBlurView = [[TSBlurView alloc] init];
             self.backgroundBlurView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
             [self addSubview:self.backgroundBlurView];

--- a/Sources/push/TSMessageView.m
+++ b/Sources/push/TSMessageView.m
@@ -72,6 +72,11 @@ static NSMutableDictionary *_notificationDesign;
     [self.contentLabel setTextColor:_contentTextColor];
 }
 
+-(void) setBannerBackgroundColor:(UIColor *)bannerBackgroundColor{
+    _bannerBackgroundColor = bannerBackgroundColor;
+    [self.backgroundBlurView setBackgroundColor:_bannerBackgroundColor];
+}
+
 -(void) setTitleFont:(UIFont *)aTitleFont{
     _titleFont = aTitleFont;
     [self.titleLabel setFont:_titleFont];
@@ -279,7 +284,7 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
             _backgroundBlurView = [[TSBlurView alloc] init];
             self.backgroundBlurView.autoresizingMask = (UIViewAutoresizingFlexibleWidth);
             //            self.backgroundBlurView.blurTintColor = [UIColor colorWithHexString:current[@"backgroundColor"]];
-            self.backgroundBlurView.blurTintColor = [UIColor blackColor];
+//            self.backgroundBlurView.blurTintColor = [UIColor redColor];
             [self addSubview:self.backgroundBlurView];
         }
 

--- a/Sources/push/TSMessageView.m
+++ b/Sources/push/TSMessageView.m
@@ -11,6 +11,7 @@
 #import "TSBlurView.h"
 #import "TSMessage.h"
 #import "ALUtilityClass.h"
+#import <QuartzCore/QuartzCore.h>
 
 #define TSMessageViewMinimumPadding 15.0
 
@@ -75,6 +76,26 @@ static NSMutableDictionary *_notificationDesign;
 -(void) setBannerBackgroundColor:(UIColor *)bannerBackgroundColor{
     _bannerBackgroundColor = bannerBackgroundColor;
     [self.backgroundBlurView setBackgroundColor:_bannerBackgroundColor];
+}
+
+-(void) setBannerShadowColor:(UIColor *)bannerShadowColor{
+    _bannerShadowColor = bannerShadowColor;
+    self.backgroundBlurView.layer.shadowColor = _bannerShadowColor.CGColor;
+}
+
+-(void) setBannerCornerRadius:(NSNumber *)bannerCornerRadius{
+    _bannerCornerRadius = bannerCornerRadius;
+    self.backgroundBlurView.layer.cornerRadius = [_bannerCornerRadius floatValue];
+}
+
+-(void) setBannerShadowRadius:(NSNumber *)bannerShadowRadius{
+    _bannerShadowRadius = bannerShadowRadius;
+    self.backgroundBlurView.layer.shadowRadius = [_bannerShadowRadius floatValue];
+}
+
+-(void) setShadowOpacity:(NSNumber *)shadowOpacity{
+    _shadowOpacity = shadowOpacity;
+    self.backgroundBlurView.layer.shadowOpacity = [_shadowOpacity floatValue];
 }
 
 -(void) setTitleFont:(UIFont *)aTitleFont{
@@ -281,10 +302,15 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
         else
         {
             // On iOS 7 and above use a blur layer instead (not yet finished)
-            _backgroundBlurView = [[TSBlurView alloc] init];
-            self.backgroundBlurView.autoresizingMask = (UIViewAutoresizingFlexibleWidth);
+//            _backgroundBlurView = [[TSBlurView alloc] init];
+//            self.backgroundBlurView.autoresizingMask = (UIViewAutoresizingFlexibleWidth);
             //            self.backgroundBlurView.blurTintColor = [UIColor colorWithHexString:current[@"backgroundColor"]];
+            _backgroundBlurView = [[TSBlurView alloc] init];
+            self.backgroundBlurView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
             [self addSubview:self.backgroundBlurView];
+            self.backgroundBlurView.layer.shadowOffset = CGSizeMake(0, 2);
+            self.backgroundBlurView.layer.shouldRasterize = YES;
+            self.backgroundBlurView.layer.rasterizationScale = [UIScreen mainScreen].scale;
         }
 
         UIColor *fontColor = [UIColor colorWithHexString:[current valueForKey:@"textColor"]];

--- a/Sources/utilities/ALUtilityClass.m
+++ b/Sources/utilities/ALUtilityClass.m
@@ -106,6 +106,10 @@ NSString * const AL_APP_GROUPS_ACCESS_KEY = @"ALAppGroupsKey";
                     titleTestColor:(UIColor *)titleTextColor
                   contentTextColor:(UIColor *)contentTextColor
                    backgroundColor:(UIColor *)backgroundColor
+             backgroundShadowColor:(UIColor *)backgroundShadowColor
+                      shadowRadius:(NSNumber *)shadowRadius
+                      cornerRadius:(NSNumber *)cornerRadius
+                     shadowOpacity:(NSNumber *)shadowOpacity
                  completionHandler:(void (^)(BOOL))handler {
 
     if ([ALUserDefaultsHandler getNotificationMode] == AL_NOTIFICATION_DISABLE) {
@@ -135,6 +139,10 @@ NSString * const AL_APP_GROUPS_ACCESS_KEY = @"ALAppGroupsKey";
     [[TSMessageView appearance] setTitleTextColor:titleTextColor];
     [[TSMessageView appearance] setContentTextColor:contentTextColor];
     [[TSMessageView appearance] setBannerBackgroundColor:backgroundColor];
+    [[TSMessageView appearance] setBannerShadowColor:backgroundShadowColor];
+    [[TSMessageView appearance] setBannerCornerRadius:cornerRadius];
+    [[TSMessageView appearance] setBannerShadowRadius:shadowRadius];
+    [[TSMessageView appearance] setShadowOpacity:shadowOpacity];
     [TSMessage showNotificationInViewController:pushAssist.topViewController
                                           title:title
                                        subtitle:toastMessage

--- a/Sources/utilities/ALUtilityClass.m
+++ b/Sources/utilities/ALUtilityClass.m
@@ -103,6 +103,9 @@ NSString * const AL_APP_GROUPS_ACCESS_KEY = @"ALAppGroupsKey";
 + (void)thirdDisplayNotificationTS:(NSString *)toastMessage
                    andForContactId:(NSString *)contactId
                        withGroupId:(NSNumber *)groupID
+                    titleTestColor:(UIColor *)titleTextColor
+                  contentTextColor:(UIColor *)contentTextColor
+                   backgroundColor:(UIColor *)backgroundColor
                  completionHandler:(void (^)(BOOL))handler {
 
     if ([ALUserDefaultsHandler getNotificationMode] == AL_NOTIFICATION_DISABLE) {
@@ -129,9 +132,9 @@ NSString * const AL_APP_GROUPS_ACCESS_KEY = @"ALAppGroupsKey";
 
     [[TSMessageView appearance] setTitleFont:[UIFont fontWithName:@"Helvetica Neue" size:18.0]];
     [[TSMessageView appearance] setContentFont:[UIFont fontWithName:@"Helvetica Neue" size:14]];
-    [[TSMessageView appearance] setTitleTextColor:[UIColor whiteColor]];
-    [[TSMessageView appearance] setContentTextColor:[UIColor whiteColor]];
-
+    [[TSMessageView appearance] setTitleTextColor:titleTextColor];
+    [[TSMessageView appearance] setContentTextColor:contentTextColor];
+    [[TSMessageView appearance] setBannerBackgroundColor:backgroundColor];
     [TSMessage showNotificationInViewController:pushAssist.topViewController
                                           title:title
                                        subtitle:toastMessage


### PR DESCRIPTION
## Summary
- Added Customisation to update color of in App Banner. Customisation is accessible for Background Color, Title Color, Content Color.

## Code
```
            Kommunicate.defaultConfiguration.inAppBannerColor = UIColor.kmDynamicColor(light: .systemBrown, dark: .systemBlue)
            Kommunicate.defaultConfiguration.inAppBannerTextColor = UIColor.kmDynamicColor(light: .white, dark: .black)
            Kommunicate.defaultConfiguration.inAppBannerContentColor = UIColor.kmDynamicColor(light: .white, dark: .black)
            Kommunicate.defaultConfiguration.inAppBannerRadius = 12
            Kommunicate.defaultConfiguration.inAppBannerShadowRadius = 15
            Kommunicate.defaultConfiguration.inAppBannerOpacity = 0.5
            Kommunicate.defaultConfiguration.inAppBannerShadowColor = UIColor.kmDynamicColor(light: .black, dark: .red)
```

## Images (Before and After Customisation)

<img src = 'https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/assets/139110221/e80bfbc4-8b8f-4907-ad61-6553fee148fb' height = 400/> <img src = 'https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/assets/139110221/e84f4402-2b20-47db-a079-20d5773e3a7d' height = 400/>

## Video

https://github.com/Kommunicate-io/KommunicateCore-iOS-SDK/assets/139110221/ff0251e1-f055-460c-bba7-aec257953dd4

