### PR TITLE
[CM-2173] Message not getting updated after online and offline| iOS SDK

### DIFF
--- a/Sources/message/ALMessageClientService.m
+++ b/Sources/message/ALMessageClientService.m
@@ -575,6 +575,7 @@ NSString *latSyncCallTime = @"";
     }
     
     if (![latSyncCallTime  isEqual: @""] && [lastSyncTime isEqual:latSyncCallTime]) { return; }
+    latSyncCallTime = lastSyncTime;
 
     ALSLog(ALLoggerSeverityInfo, @"LAST SYNC TIME IN CALL :  %@", lastSyncTime);
 
@@ -582,6 +583,7 @@ NSString *latSyncCallTime = @"";
     [self.responseHandler authenticateAndProcessRequest:messageSyncRequest andTag:@"SYNC LATEST MESSAGE URL" WithCompletionHandler:^(id theJson, NSError *theError) {
 
         if (theError) {
+            latSyncCallTime = @"";
             [ALUserDefaultsHandler setMsgSyncRequired:YES];
             completion(nil,theError);
             return;
@@ -590,7 +592,6 @@ NSString *latSyncCallTime = @"";
         [ALUserDefaultsHandler setMsgSyncRequired:NO];
         ALSyncMessageFeed *syncResponse = [[ALSyncMessageFeed alloc] initWithJSONString:theJson];
         ALSLog(ALLoggerSeverityInfo, @"LATEST_MESSAGE_JSON: %@", (NSString *)theJson);
-        latSyncCallTime = lastSyncTime;
         completion(syncResponse,nil);
     }];
 }

--- a/Sources/message/ALMessageClientService.m
+++ b/Sources/message/ALMessageClientService.m
@@ -575,7 +575,6 @@ NSString *latSyncCallTime = @"";
     }
     
     if (![latSyncCallTime  isEqual: @""] && [lastSyncTime isEqual:latSyncCallTime]) { return; }
-    latSyncCallTime = lastSyncTime;
 
     ALSLog(ALLoggerSeverityInfo, @"LAST SYNC TIME IN CALL :  %@", lastSyncTime);
 
@@ -591,6 +590,7 @@ NSString *latSyncCallTime = @"";
         [ALUserDefaultsHandler setMsgSyncRequired:NO];
         ALSyncMessageFeed *syncResponse = [[ALSyncMessageFeed alloc] initWithJSONString:theJson];
         ALSLog(ALLoggerSeverityInfo, @"LATEST_MESSAGE_JSON: %@", (NSString *)theJson);
+        latSyncCallTime = lastSyncTime;
         completion(syncResponse,nil);
     }];
 }


### PR DESCRIPTION
## Summary

- Updating the value of `latSyncCallTime` to empty String if any network failure happens.
- Earlier the `latSyncCallTime` is getting updated to latest time resulting in returning  the function before the network call.