### PR TITLE
SPM Info Plist Added | iOS SDK ( SPM )

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -44,7 +44,13 @@ let package = Package(
             linkerSettings: [
                 .linkedFramework("Foundation"),
                 .linkedFramework("SystemConfiguration"),
-                .linkedFramework("UIKit", .when(platforms: [.iOS]))
+                .linkedFramework("UIKit", .when(platforms: [.iOS])),
+                .unsafeFlags([
+                    "-Xlinker", "-sectcreate",
+                    "-Xlinker", "__TEXT",
+                    "-Xlinker", "__info_plist",
+                    "-Xlinker", "Sources/KommunicateCore-Info.plist"
+                ])
             ]
         )
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,8 @@ let package = Package(
             exclude: ["Info.plist",
                       "MQTT/MQTTClient-Prefix.pch"],
             resources: [
-                .process("Resources")
+                .process("Resources"),
+                .process("KommunicateCore-Info.plist")
             ],
             cSettings: [
                 .headerSearchPath(""),

--- a/Package.swift
+++ b/Package.swift
@@ -44,13 +44,7 @@ let package = Package(
             linkerSettings: [
                 .linkedFramework("Foundation"),
                 .linkedFramework("SystemConfiguration"),
-                .linkedFramework("UIKit", .when(platforms: [.iOS])),
-                .unsafeFlags([
-                    "-Xlinker", "-sectcreate",
-                    "-Xlinker", "__TEXT",
-                    "-Xlinker", "__info_plist",
-                    "-Xlinker", "Sources/KommunicateCore-Info.plist"
-                ])
+                .linkedFramework("UIKit", .when(platforms: [.iOS]))
             ]
         )
     ],


### PR DESCRIPTION
## Summary 
- Added `KommunicateCore-Info.plist` file in project in SMP. 
- Implemented new method to export the `KMExpectedPublicKeyHashBase64`.