### PR TITLE
[CM-2115] Group v5 Calls Optimisation | iOS Agent App

### DIFF
--- a/Sources/channel/ALChannelClientService.m
+++ b/Sources/channel/ALChannelClientService.m
@@ -437,6 +437,8 @@ static NSString *const REMOVE_MULTIPLE_SUB_GROUP = @"/rest/ws/group/remove/subgr
 
 #pragma mark - Channel Sync
 
+NSString *latSyncCallTimeForChannel = @"";
+
 - (void)syncCallForChannel:(NSNumber *)updatedAt
       withFetchUserDetails:(BOOL)fetchUserDetails
              andCompletion:(void(^)(NSError *error, ALChannelSyncResponse *response))completion {
@@ -446,7 +448,13 @@ static NSString *const REMOVE_MULTIPLE_SUB_GROUP = @"/rest/ws/group/remove/subgr
     if (updatedAt != nil || updatedAt != NULL){
         syncChannelParamString  = [NSString stringWithFormat:@"updatedAt=%@", updatedAt];
     }
-
+    
+    NSString *updatedAtString = [updatedAt stringValue];
+    
+    if (![latSyncCallTimeForChannel isEqual: @""] && [updatedAtString isEqual:latSyncCallTimeForChannel]) { return; }
+    
+    latSyncCallTimeForChannel = updatedAtString;
+    
     NSMutableURLRequest *syncChannelRequest = [ALRequestHandler createGETRequestWithUrlString:syncChannelURLString paramString:syncChannelParamString];
 
     [self.responseHandler authenticateAndProcessRequest:syncChannelRequest andTag:@"CHANNEL_SYNCHRONIZATION" WithCompletionHandler:^(id theJson, NSError *error) {
@@ -490,6 +498,7 @@ static NSString *const REMOVE_MULTIPLE_SUB_GROUP = @"/rest/ws/group/remove/subgr
                                   userInfo:[NSDictionary
                                             dictionaryWithObject:@"Status fail in response"
                                             forKey:NSLocalizedDescriptionKey]];
+                latSyncCallTimeForChannel = @"";
                 completion(error, nil);
                 return;
             }


### PR DESCRIPTION
## Summary

- Implemented code to store the last update time locally and check if the API's last update time differs from the stored value.
- In case of an API failure, the last update time is reset to nil to avoid affecting future API calls.