### PR TITLE
[CM-2277] SSL Pining Disabling Configuration | iOS SDK

### DIFF
--- a/Sources/include/ALUserDefaultsHandler.h
+++ b/Sources/include/ALUserDefaultsHandler.h
@@ -31,6 +31,7 @@ static NSString *const AL_CONVERSATION_CONTACT_IMAGE_VISIBILITY = @"com.applozic
 static NSString *const AL_MSG_LIST_CALL_SUFIX = @"com.applozic.userdefault.MSG_CALL_MADE:";
 static NSString *const AL_PROCESSED_NOTIFICATION_IDS  = @"com.applozic.userdefault.PROCESSED_NOTIFICATION_IDS";
 static NSString *const AL_TEAM_MODE_ENABLED  = @"com.applozic.userdefault.TEAM_MODE_ENABLED";
+static NSString *const AL_KM_SSL_PINNING_ENABLED = @"com.applozic.userdefault.KM_SSL_PINNING_ENABLED";
 static NSString *const AL_ASSIGNED_TEAM_IDS  = @"com.applozic.userdefault.ASSIGNED_TEAM_IDS";
 static NSString *const AL_LAST_SEEN_SYNC_TIME = @"com.applozic.userdefault.LAST_SEEN_SYNC_TIME";
 static NSString *const AL_SHOW_LOAD_ERLIER_MESSAGE = @"com.applozic.userdefault.SHOW_LOAD_ERLIER_MESSAGE:";
@@ -304,6 +305,9 @@ static NSString *const AL_VOIP_DEVICE_TOKEN = @"com.applozic.userdefault.VOIP_DE
 
 + (void)deactivateLoggedInUser:(BOOL)deactivate;
 + (BOOL)isLoggedInUserDeactivated;
+
++ (void)setKMSSLPinningEnabled:(BOOL)flag;
++ (BOOL)isKMSSLPinningEnabled;
 
 + (void)setChannelListLastSyncGeneratedTime:(NSNumber *)lastSyncGeneratedTime;
 + (NSNumber *)getChannelListLastSyncGeneratedTime;

--- a/Sources/networkcommunication/ALResponseHandler.m
+++ b/Sources/networkcommunication/ALResponseHandler.m
@@ -228,6 +228,13 @@ completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition disposition, NS
         return;
     }
 
+    if (![ALUserDefaultsHandler isKMSSLPinningEnabled]) {
+        // SSL pinning is disabled, trust the server's certificate
+        NSURLCredential *credential = [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust];
+        completionHandler(NSURLSessionAuthChallengeUseCredential, credential);
+        return;
+    }
+    
     // Load the expected public key hashes from the Info.plist
     NSBundle *bundle = [ALUtilityClass getBundle];
     NSArray *kExpectedPublicKeyHashBase64 = [self fetchExpectedPublicKeyHashesFromBundle:bundle];

--- a/Sources/prefrence/ALUserDefaultsHandler.m
+++ b/Sources/prefrence/ALUserDefaultsHandler.m
@@ -332,6 +332,21 @@
     return [userDefaults boolForKey:AL_TEAM_MODE_ENABLED];
 }
 
++ (void)setKMSSLPinningEnabled:(BOOL)flag {
+    NSUserDefaults *userDefaults = [ALUserDefaultsHandler getUserDefaults];
+    [userDefaults setBool:flag forKey:AL_KM_SSL_PINNING_ENABLED];
+    [userDefaults synchronize];
+}
+
++ (BOOL)isKMSSLPinningEnabled {
+    NSUserDefaults *userDefaults = [ALUserDefaultsHandler getUserDefaults];
+    // Check if the key exists and return false if the value is null or does not exist
+    if (![userDefaults objectForKey:AL_KM_SSL_PINNING_ENABLED]) {
+        return NO;
+    }
+    return [userDefaults boolForKey:AL_KM_SSL_PINNING_ENABLED];
+}
+
 + (void)setAssignedTeamIds:(NSMutableArray *)assignedTeamIDs {
     NSUserDefaults *userDefaults = [ALUserDefaultsHandler getUserDefaults];
     [userDefaults setObject:assignedTeamIDs forKey:AL_ASSIGNED_TEAM_IDS];


### PR DESCRIPTION
## Summary
- Added the configuration to store the value of enabled or disabled SSL Pinning. 
- Created the check to identify if the SSL pinning is enabled then Bypass the Certificate Check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced SSL pinning functionality to enhance security settings.
	- Added methods to enable and check the status of SSL pinning within user defaults.

- **Bug Fixes**
	- Improved error handling and logging for SSL challenges.

- **Documentation**
	- Updated logging statements for clarity regarding the SSL pinning process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->