### PR TITLE
[CM-2409] Real Time Assignment Status Update Flow Migrate| iOS SDK

### DIFF
--- a/Sources/channel/ALChannelClientService.m
+++ b/Sources/channel/ALChannelClientService.m
@@ -505,15 +505,15 @@ NSString *latSyncCallTimeForChannel = @"";
     }];
 }
 
-#pragma mark - Perticular Channel Sync
+#pragma mark - Specific Channel Sync
 
-- (void)syncCallForSpesificChannel:(NSNumber *)groupID
+- (void)syncCallForSpecificChannel:(NSNumber *)groupID
               withFetchUserDetails:(BOOL)fetchUserDetails
                      andCompletion:(void(^)(NSError *error, ALChannelSyncResponse *response))completion {
     NSString *syncChannelURLString = [NSString stringWithFormat:@"%@%@", KBASE_URL, CHANNEL_INFO_SYNC_URL];
     NSString *syncChannelParamString = nil;
 
-    if (groupID != nil || groupID != NULL){
+    if (groupID != nil && groupID != NULL){
         syncChannelParamString  = [NSString stringWithFormat:@"groupId=%@", groupID];
     } else {
         return;
@@ -535,9 +535,8 @@ NSString *latSyncCallTimeForChannel = @"";
             if ([response.status isEqualToString:AL_RESPONSE_SUCCESS]) {
                 if (fetchUserDetails) {
                     ALContactService *contactService = [ALContactService new];
-                    for (ALChannel *channel in response.alChannelArray) {
-
-                        for (NSString *userId in channel.membersName) {
+                    if (response.alChannel) {
+                        for (NSString *userId in response.alChannel.membersName) {
                             if (![contactService isContactExist:userId]){
                                 [userNotPresentIds addObject:userId];
                             }

--- a/Sources/channel/ALChannelService.m
+++ b/Sources/channel/ALChannelService.m
@@ -750,10 +750,10 @@ dispatch_queue_t channelUserbackgroundQueue;
 
 }
 
-- (void)syncCallForSpesificChannelWithDelegate:(id<KommunicateUpdatesDelegate>)delegate
+- (void)syncCallForSpecificChannelWithDelegate:(id<KommunicateUpdatesDelegate>)delegate
                                     channelKey:(NSNumber *)channelKey {
 
-    [self.channelClientService syncCallForSpesificChannel:channelKey withFetchUserDetails:YES andCompletion:^(NSError *error, ALChannelSyncResponse *response) {
+    [self.channelClientService syncCallForSpecificChannel:channelKey withFetchUserDetails:YES andCompletion:^(NSError *error, ALChannelSyncResponse *response) {
         if (!error) {
             [self createChannelAndUpdateInfo:response.alChannel withDelegate:delegate];
             [[NSNotificationCenter defaultCenter] postNotificationName:@"UPDATE_CHANNEL_NAME" object:nil];

--- a/Sources/channel/ALChannelService.m
+++ b/Sources/channel/ALChannelService.m
@@ -750,6 +750,19 @@ dispatch_queue_t channelUserbackgroundQueue;
 
 }
 
+- (void)syncCallForSpesificChannelWithDelegate:(id<KommunicateUpdatesDelegate>)delegate
+                                    channelKey:(NSNumber *)channelKey {
+
+    [self.channelClientService syncCallForSpesificChannel:channelKey withFetchUserDetails:YES andCompletion:^(NSError *error, ALChannelSyncResponse *response) {
+        if (!error) {
+            [self createChannelAndUpdateInfo:response.alChannel withDelegate:delegate];
+            [[NSNotificationCenter defaultCenter] postNotificationName:@"UPDATE_CHANNEL_NAME" object:nil];
+            [[NSNotificationCenter defaultCenter] postNotificationName:@"UPDATE_CHANNEL_METADATA" object:nil];
+        }
+    }];
+
+}
+
 #pragma mark - Mark conversation as read
 
 - (void)markConversationAsRead:(NSNumber *)channelKey withCompletion:(void (^)(NSString *, NSError *))completion {
@@ -1269,6 +1282,22 @@ dispatch_queue_t channelUserbackgroundQueue;
 
         [[NSNotificationCenter defaultCenter] postNotificationName:@"Update_channel_Info" object:channelObject];
     }
+}
+
+- (void)createChannelAndUpdateInfo:(ALChannel *)channelObject withDelegate:(id<KommunicateUpdatesDelegate>)delegate {
+    // Ignore inserting un opened conversation(Which doesn't have user messages, only contains bot messages)
+    NSDictionary *metadata = channelObject.metadata;
+    if (metadata && metadata[AL_CHANNEL_CONVERSATION_STATUS] && [metadata[AL_CHANNEL_CONVERSATION_STATUS] isEqual:UN_OPENED_CONVERSATION_STATUS] ) {
+        return;
+    }
+    // Ignore inserting unread count in sync call
+    channelObject.unreadCount = 0;
+    [self createChannelEntry:channelObject fromMessageList:NO];
+    if (delegate) {
+        [delegate onChannelUpdated:channelObject];
+    }
+
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"Update_channel_Info" object:channelObject];
 }
 
 #pragma mark - List of Channels where Login user in Channel

--- a/Sources/channel/ALChannelSyncResponse.m
+++ b/Sources/channel/ALChannelSyncResponse.m
@@ -31,4 +31,18 @@
     
 }
 
+- (instancetype)initWithSingleChannelJSONString:(NSString *)JSONString {
+    self = [super initWithJSONString:JSONString];
+    self.alChannel = [[ALChannel alloc] init];
+    
+    if ([super.status isEqualToString: AL_RESPONSE_SUCCESS]) {
+        NSDictionary *response = [JSONString valueForKey:@"response"];
+        ALChannel *alChannel = [[ALChannel alloc] initWithDictonary:response];
+        self.alChannel = alChannel;
+        return self;
+    } else {
+        return nil;
+    }
+}
+
 @end

--- a/Sources/include/ALChannelClientService.h
+++ b/Sources/include/ALChannelClientService.h
@@ -87,7 +87,7 @@ static NSString *const GROUP_FETCH_BATCH_SIZE = @"100";
       withFetchUserDetails:(BOOL)fetchUserDetails
              andCompletion:(void(^)(NSError *error, ALChannelSyncResponse *response))completion;
 
-- (void)syncCallForSpesificChannel:(NSNumber *)channelKey
+- (void)syncCallForSpecificChannel:(NSNumber *)channelKey
       withFetchUserDetails:(BOOL)fetchUserDetails
              andCompletion:(void(^)(NSError *error, ALChannelSyncResponse *response))completion;
 

--- a/Sources/include/ALChannelClientService.h
+++ b/Sources/include/ALChannelClientService.h
@@ -87,6 +87,10 @@ static NSString *const GROUP_FETCH_BATCH_SIZE = @"100";
       withFetchUserDetails:(BOOL)fetchUserDetails
              andCompletion:(void(^)(NSError *error, ALChannelSyncResponse *response))completion;
 
+- (void)syncCallForSpesificChannel:(NSNumber *)channelKey
+      withFetchUserDetails:(BOOL)fetchUserDetails
+             andCompletion:(void(^)(NSError *error, ALChannelSyncResponse *response))completion;
+
 - (void)markConversationAsRead:(NSNumber *)channelKey withCompletion:(void (^)(NSString *, NSError *))completion;
 
 - (void)addChildKeyList:(NSMutableArray *)childKeyList

--- a/Sources/include/ALChannelService.h
+++ b/Sources/include/ALChannelService.h
@@ -492,6 +492,12 @@ extern NSString *const AL_MESSAGE_SYNC;
 /// @param delegate For real time updates callback will be triggered for channel update
 - (void)syncCallForChannelWithDelegate:(id<KommunicateUpdatesDelegate>)delegate;
 
+/// This method is used for internal purpose.
+/// @param delegate For real time updates callback will be triggered for channel update
+/// @param channelKey For calling fetch API For Spesific Channel
+- (void)syncCallForSpesificChannelWithDelegate:(id<KommunicateUpdatesDelegate>)delegate
+                                    channelKey:(NSNumber *)channelKey;
+
 - (void)updateConversationReadWithGroupId:(NSNumber *)channelKey withDelegate:(id<KommunicateUpdatesDelegate>)delegate;
 
 /// This method is used for creating a channel.

--- a/Sources/include/ALChannelService.h
+++ b/Sources/include/ALChannelService.h
@@ -494,8 +494,8 @@ extern NSString *const AL_MESSAGE_SYNC;
 
 /// This method is used for internal purpose.
 /// @param delegate For real time updates callback will be triggered for channel update
-/// @param channelKey For calling fetch API For Spesific Channel
-- (void)syncCallForSpesificChannelWithDelegate:(id<KommunicateUpdatesDelegate>)delegate
+/// @param channelKey For calling fetch API For Specific Channel
+- (void)syncCallForSpecificChannelWithDelegate:(id<KommunicateUpdatesDelegate>)delegate
                                     channelKey:(NSNumber *)channelKey;
 
 - (void)updateConversationReadWithGroupId:(NSNumber *)channelKey withDelegate:(id<KommunicateUpdatesDelegate>)delegate;

--- a/Sources/include/ALChannelSyncResponse.h
+++ b/Sources/include/ALChannelSyncResponse.h
@@ -14,6 +14,11 @@
 
 @property (nonatomic, strong) NSMutableArray *alChannelArray;
 
+@property (nonatomic, strong) ALChannel *alChannel;
+
 - (instancetype)initWithJSONString:(NSString *)JSONString;
+
+// Initializer for a single channel
+- (instancetype)initWithSingleChannelJSONString:(NSString *)JSONString;
 
 @end

--- a/Sources/message/ALMessageService.m
+++ b/Sources/message/ALMessageService.m
@@ -447,7 +447,7 @@ static ALMessageClientService *alMsgClientService;
                      postNotificationName:@"CONVERSATION_DELETION"
                      object:message.groupId];
                 }
-                [[ALChannelService sharedInstance] syncCallForSpesificChannelWithDelegate:delegate channelKey: message.groupId];
+                [[ALChannelService sharedInstance] syncCallForSpecificChannelWithDelegate:delegate channelKey: message.groupId];
             }
 
             [self resetUnreadCountAndUpdate:message];

--- a/Sources/message/ALMessageService.m
+++ b/Sources/message/ALMessageService.m
@@ -447,7 +447,7 @@ static ALMessageClientService *alMsgClientService;
                      postNotificationName:@"CONVERSATION_DELETION"
                      object:message.groupId];
                 }
-                [[ALChannelService sharedInstance] syncCallForChannelWithDelegate:delegate];
+                [[ALChannelService sharedInstance] syncCallForSpesificChannelWithDelegate:delegate channelKey: message.groupId];
             }
 
             [self resetUnreadCountAndUpdate:message];


### PR DESCRIPTION
## Summary
- Migrated the V5 Sync Api Call `chat.kommuniate.io/rest/ws/group/v5/list` to  V2 Info with group ID param `chat.kommunicate.io/rest/ws/group/v2/info`. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to synchronize and update information for a specific channel, including user details, using new methods in the channel management interface.
  - Introduced support for handling single-channel responses and updates, improving efficiency when syncing individual channels.

- **Bug Fixes**
  - Improved message processing to synchronize only the relevant channel when handling channel notification messages.

- **Documentation**
  - Updated public interfaces to reflect new methods and properties for single-channel synchronization and response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->