### PR TITLE
[CM-2457] Create a method to clear old data in iOS Agent App | iOS SDK

### DIFF
--- a/Sources/include/KMCoreUserDefaultsHandler.h
+++ b/Sources/include/KMCoreUserDefaultsHandler.h
@@ -82,6 +82,7 @@ static NSString *const KM_CORE_INITIAL_MESSAGE_LIST_CALL = @"io.kommunicate.core
 static NSString *const KM_CORE_LOGGED_IN_USER_DEACTIVATED = @"io.kommunicate.core.userdefault.AL_LOGGED_IN_USER_DEACTIVATED";
 static NSString *const KM_CORE_CHANNEL_LIST_LAST_GENERATED_TIME = @"io.kommunicate.core.userdefault.AL_CHANNEL_LIST_LAST_GENERATED_TIME";
 static NSString *const KM_CORE_VOIP_DEVICE_TOKEN = @"io.kommunicate.core.userdefault.VOIP_DEVICE_TOKEN";
+static NSString *const KM_CORE_AGENT_APP_CLEANUP_LAST_TIME = @"io.kommunicate.core.userdefault.KM_CORE_AGENT_APP_CLEANUP_LAST_TIME";
 
 @interface KMCoreUserDefaultsHandler : NSObject
 
@@ -156,6 +157,12 @@ static NSString *const KM_CORE_VOIP_DEVICE_TOKEN = @"io.kommunicate.core.userdef
 + (void)setServerCallDoneForMSGList:(BOOL)value forContactId:(NSString *)constactId;
 
 + (BOOL)isServerCallDoneForMSGList:(NSString *)contactId;
+
++ (void)removeServerCallDoneForMSGListForContactIds:(NSArray<NSString *> *)contactIds;
+
++ (void)setLastCleanupTimeForAgentApp:(NSDate *)date;
+
++ (NSDate *)getLastCleanupTimeForAgentApp;
 
 + (void)setProcessedNotificationIds:(NSMutableArray *)arrayWithIds;
 

--- a/Sources/prefrence/KMCoreUserDefaultsHandler.m
+++ b/Sources/prefrence/KMCoreUserDefaultsHandler.m
@@ -311,6 +311,37 @@
     return [userDefaults boolForKey:key];
 }
 
++ (void)removeServerCallDoneForMSGListForContactIds:(NSArray<NSString *> *)contactIds {
+    if (!contactIds || contactIds.count == 0) {
+        return;
+    }
+
+    NSUserDefaults *userDefaults = [KMCoreUserDefaultsHandler getUserDefaults];
+
+    for (NSString *contactId in contactIds) {
+        if (contactId.length == 0) {
+            continue;
+        }
+
+        NSString *key = [KM_CORE_MSG_LIST_CALL_SUFIX stringByAppendingString:contactId];
+        [userDefaults removeObjectForKey:key];
+    }
+
+    [userDefaults synchronize];
+}
+
++ (void)setLastCleanupTimeForAgentApp:(NSDate *)date {
+    if (!date) return;
+    NSUserDefaults *userDefaults = [KMCoreUserDefaultsHandler getUserDefaults];
+    [userDefaults setObject:date forKey:KM_CORE_AGENT_APP_CLEANUP_LAST_TIME];
+    [userDefaults synchronize];
+}
+
++ (NSDate *)getLastCleanupTimeForAgentApp {
+    NSUserDefaults *userDefaults = [KMCoreUserDefaultsHandler getUserDefaults];
+    return [userDefaults objectForKey:KM_CORE_AGENT_APP_CLEANUP_LAST_TIME];
+}
+
 + (void)setProcessedNotificationIds:(NSMutableArray *)arrayWithIds {
     NSUserDefaults *userDefaults = [KMCoreUserDefaultsHandler getUserDefaults];
     [userDefaults setObject:arrayWithIds forKey:KM_CORE_PROCESSED_NOTIFICATION_IDS];


### PR DESCRIPTION
## Summary 
- Added a function to update saved message list from user defaults.
- Added a method to store and get last data cleanup time.