### PR TITLE
TDH-3643 : Compilation Error in Xcode-26.4

### DIFF
--- a/Sources/networkcommunication/ALReachability.m
+++ b/Sources/networkcommunication/ALReachability.m
@@ -29,7 +29,6 @@
 
 #import <sys/socket.h>
 #import <netinet/in.h>
-#import <netinet6/in6.h>
 #import <arpa/inet.h>
 #import <ifaddrs.h>
 #import <netdb.h>
@@ -472,3 +471,4 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
 }
 
 @end
+


### PR DESCRIPTION

 ### Replace private netinet6 header with public netinet import in ALReachability  

Removed direct import of private header netinet6​/in6​.h that caused build errors (“Use of private header from outside its module”).
• Kept/publicly rely on netinet​/in​.h, which already exposes necessary IPv4/IPv6 types and constants.
• No functional changes to reachability logic; this is a compatibility and build-fix update to stay within the public SDK surface.