### PR TITLE
Release 1.3.2 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 
 The changelog for [KommunicateCore-iOS-SDK](https://github.com/Kommunicate-io/KommunicateCore-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateCore-iOS-SDK/releases) on Github.
+## [1.3.2] 2026-04-21
+- Xcode 26.4 Support
+- Settings for Images
 ## [1.3.1] 2025-09-16
 - Real Time Status Fetch API Migration.
 - Bug Fixes.

--- a/KommunicateCore-iOS-SDK.podspec
+++ b/KommunicateCore-iOS-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'KommunicateCore-iOS-SDK'
-  s.version          = '1.3.1'
+  s.version          = '1.3.2'
   s.summary          = 'KommunicateCore-iOS SDK pod'
   s.description      = <<-DESC
 The KommunicateCore-iOS SDK helps you build your own custom UI in your iOS app

--- a/Sources/KommunicateCore-Info.plist
+++ b/Sources/KommunicateCore-Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.1</string>
+	<string>1.3.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Sources/networkcommunication/ALReachability.m
+++ b/Sources/networkcommunication/ALReachability.m
@@ -29,7 +29,6 @@
 
 #import <sys/socket.h>
 #import <netinet/in.h>
-#import <netinet6/in6.h>
 #import <arpa/inet.h>
 #import <ifaddrs.h>
 #import <netdb.h>
@@ -472,3 +471,4 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
 }
 
 @end
+


### PR DESCRIPTION
# Xcode 26.4 Support

```#import <netinet6/in6.h>``` is removed to avoid compilation error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Xcode 26.4 support
  * New image settings configuration

* **Chores**
  * Version bumped to 1.3.2
  * Minor code cleanup and maintenance updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->